### PR TITLE
Improve initial loading with dynamic imports

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ['moment-timezone'],
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
   // Any other Next.js config options
 };
 

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -7,12 +7,12 @@ export default function Header() {
       <nav>
         <ul className="flex space-x-4">
           <li>
-            <Link href="/auth/login" className="text-gray-700 hover:text-indigo-600">
+            <Link prefetch={false} href="/auth/login" className="text-gray-700 hover:text-indigo-600">
               Giriş Yap
             </Link>
           </li>
           <li>
-            <Link href="/auth/register" className="text-gray-700 hover:text-indigo-600">
+            <Link prefetch={false} href="/auth/register" className="text-gray-700 hover:text-indigo-600">
               Kayıt Ol
             </Link>
           </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,21 @@
-import Header from "./components/Header";
-import HeroSection from "./components/HeroSection";
-import CustomerBenefits from "./components/CustomerBenefits";
-import BarberBenefits from "./components/BarberBenefits";
-import Testimonials from "./components/Testimonials";
-import Footer from "./components/Footer";
+import dynamic from "next/dynamic";
+
+const Header = dynamic(() => import("./components/Header"));
+const HeroSection = dynamic(() => import("./components/HeroSection"), {
+  loading: () => <p>Yükleniyor...</p>,
+});
+const CustomerBenefits = dynamic(
+  () => import("./components/CustomerBenefits"),
+  { loading: () => <p>Yükleniyor...</p> }
+);
+const BarberBenefits = dynamic(
+  () => import("./components/BarberBenefits"),
+  { loading: () => <p>Yükleniyor...</p> }
+);
+const Testimonials = dynamic(() => import("./components/Testimonials"), {
+  loading: () => <p>Yükleniyor...</p>,
+});
+const Footer = dynamic(() => import("./components/Footer"));
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- dynamically import home page sections
- disable prefetch for header links
- enable modern image formats in `next.config`

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab649eee88321af0274b56141bccb